### PR TITLE
CI build improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build with Gradle
-        run: gradle build
+        run: gradlew build
+        env:
+          CI: ""
       - name: Check bundle
         run: ls ./bundle -l
       - name: Upload Artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Build with Gradle
-        run: gradlew build
+        run: ./gradlew build
         env:
           CI: ""
       - name: Check bundle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Build with Gradle
         run: gradlew build
         env:

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -40,7 +40,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build with Gradle
-        run: gradle build
+        run: gradlew build
+        env:
+          CI: ""
       - name: Check bundle
         run: ls ./bundle -l
       - name: Upload Artifact

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Build with Gradle
-        run: gradlew build
+        run: ./gradlew build
         env:
           CI: ""
       - name: Check bundle

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -39,6 +39,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Build with Gradle
         run: gradlew build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,9 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
         
       - name: Build with Gradle
-        run: gradle -Pversion="${{ steps.get_version.outputs.VERSION }}" build
+        run: gradlew -Pversion="${{ steps.get_version.outputs.VERSION }}" build
         env:
-          USERNAME: ${{ github.actor }}
-          TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+          CI: ""
           
       - name: Check bundle
         run: ls ./bundle -l

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-        
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       - name: Build with Gradle
         run: gradlew -Pversion="${{ steps.get_version.outputs.VERSION }}" build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: gradlew -Pversion="${{ steps.get_version.outputs.VERSION }}" build
+        run: ./gradlew -Pversion="${{ steps.get_version.outputs.VERSION }}" build
         env:
           CI: ""
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
       # Testing
       #
       - name: Test with Gradle
-        run: gradle test
+        run: gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
       # Testing
       #
       - name: Test with Gradle
-        run: gradlew test
+        run: ./gradlew test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-    
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       #
       # Testing
       #


### PR DESCRIPTION
- ignore warnings in yarn build
- use gradlew instead of gradle command