### PR TITLE
Forced parsing engine result to double

### DIFF
--- a/src/util/EngineUtil.kt
+++ b/src/util/EngineUtil.kt
@@ -19,7 +19,7 @@ fun String.toDoubleFunction(): DoubleFunction {
         // Inserts the function
         engine.eval("function $functionName(x) { return parseFloat($this); }");
 
-        { x: Double -> engine.eval("$functionName($x);") as Double }
+        { x: Double -> engine.eval("$functionName($x);").toString().toDouble() }
     }
 }
 


### PR DESCRIPTION
Sometimes the engine returned integer instead of double. Now the result ll be parsed to string and then to double.