### PR TITLE
Fixed wrong unit of heat demand in Massenstrom

### DIFF
--- a/src/util/MathUtil.kt
+++ b/src/util/MathUtil.kt
@@ -16,7 +16,7 @@ const val WATER_DICHTE = 997.0
  * @return Double - Massenstrom in kg/s
  */
 fun massenstrom(flowIn: Double, flowOut: Double, heatDemand: Double, c: Double = 4.187) =
-    (heatDemand) / (c * (flowIn - flowOut))
+    (heatDemand / 1000) / (c * (flowIn - flowOut))
 
 /**
  * Berechnet den Volumenstrom aus Temperaturdifferenz, Wärmebedarf und der Dichte des Mediums.


### PR DESCRIPTION
Der Wärmebedarf muss in kWh eingegeben werden nicht in Wh. Entsprechend / 1000 geteilt