### PR TITLE
Performance boost: Lazy property calculation

### DIFF
--- a/src/model/Pipe.kt
+++ b/src/model/Pipe.kt
@@ -1,6 +1,6 @@
 package de.fhac.ewi.model
 
-import de.fhac.ewi.model.delegate.SubscribableDelegate
+import de.fhac.ewi.model.delegate.SubscribableProperty
 import de.fhac.ewi.model.math.*
 
 data class Pipe(
@@ -11,7 +11,7 @@ data class Pipe(
     val coverageHeight: Double // in m
 ) {
 
-    var type by SubscribableDelegate(PipeType.UNDEFINED)
+    var type by SubscribableProperty(PipeType.UNDEFINED)
 
     val heatLoss by PipeHeatLossDelegate(this)
 

--- a/src/model/delegate/LazyCalculableDoubleArray.kt
+++ b/src/model/delegate/LazyCalculableDoubleArray.kt
@@ -5,17 +5,12 @@ package de.fhac.ewi.model.delegate
  *
  * @param T - Keine Ahnung
  */
-abstract class CalculableDelegate<T> : SubscribableDelegate<T, DoubleArray>() {
+abstract class LazyCalculableDoubleArray<T> : LazyCalculableProperty<T, DoubleArray>() {
 
     abstract fun recalculateIndexed(index: Int): Double
 
-    open fun recalculate(): DoubleArray = DoubleArray(8760) { recalculateIndexed(it) }
-
-    fun updateValue() {
-        setValue(recalculate())
-    }
+    override fun recalculate(): DoubleArray = DoubleArray(8760) { recalculateIndexed(it) }
 
     override fun hasChanged(oldValue: DoubleArray, newValue: DoubleArray) = !(oldValue contentEquals newValue)
 
-    override fun lazyInitialValue() = recalculate()
 }

--- a/src/model/delegate/LazyCalculableProperty.kt
+++ b/src/model/delegate/LazyCalculableProperty.kt
@@ -1,0 +1,55 @@
+package de.fhac.ewi.model.delegate
+
+import kotlin.reflect.KProperty
+
+abstract class LazyCalculableProperty<T, V : Any> : SubscribableProperty<T, V>(), LazySubscriber {
+
+    var possibleUpdate = false
+    var recalculate = false
+
+    override fun getValue(thisRef: T, property: KProperty<*>): V {
+        if (possibleUpdate && !recalculate) {
+            checkForChanges()
+            possibleUpdate = false // we checked - if there must be an update then recalculate now should be set
+        }
+        if (recalculate)
+            updateValue()
+        return super.getValue(thisRef, property)
+    }
+
+    abstract fun checkForChanges()
+
+    abstract fun recalculate(): V
+
+    override fun lazyInitialValue() = recalculate()
+
+    private fun updateValue() {
+        setValue(recalculate())
+        recalculate = false
+        possibleUpdate = false
+    }
+
+    /**
+     * Gets triggered if there might be an update for this value.
+     */
+    override fun onPossibleUpdate() {
+        if (possibleUpdate)
+            return // possible update already triggered
+
+        possibleUpdate = true
+        subscribers.filterIsInstance<LazySubscriber>().forEach(LazySubscriber::onPossibleUpdate)
+    }
+
+    /**
+     * Gets triggered if this value needs to be recalculated.
+     */
+    override fun onValueChange() {
+        if (recalculate)
+            return // recalculation already triggered
+
+        recalculate = true
+        if (!possibleUpdate) // if possible update not already announced
+            subscribers.filterIsInstance<LazySubscriber>().forEach(LazySubscriber::onPossibleUpdate)
+        possibleUpdate = false // possible update now false, because we already forced an recalculation
+    }
+}

--- a/src/model/delegate/LazySubscriber.kt
+++ b/src/model/delegate/LazySubscriber.kt
@@ -1,0 +1,5 @@
+package de.fhac.ewi.model.delegate
+
+interface LazySubscriber: Subscriber {
+    fun onPossibleUpdate()
+}

--- a/src/model/delegate/PipeBasedCalculableDelegate.kt
+++ b/src/model/delegate/PipeBasedCalculableDelegate.kt
@@ -8,7 +8,7 @@ import de.fhac.ewi.model.Pipe
  * @param T
  * @property connectedPipes MutableList<Pipe> - Child pipes
  */
-abstract class PipeBasedCalculableDelegate<T> : CalculableDelegate<T>() {
+abstract class PipeBasedCalculableDelegate<T> : LazyCalculableDoubleArray<T>() {
 
     private val connectedPipes = mutableListOf<Pipe>()
 
@@ -25,4 +25,9 @@ abstract class PipeBasedCalculableDelegate<T> : CalculableDelegate<T>() {
     abstract fun recalculateIndexed(index: Int, pipes: List<Pipe>): Double
     abstract fun onPipeConnect(pipe: Pipe)
 
+    abstract fun onPossiblePipeUpdate(pipe: Pipe)
+
+    override fun checkForChanges() {
+        connectedPipes.forEach(::onPossiblePipeUpdate)
+    }
 }

--- a/src/model/delegate/SubscribableProperty.kt
+++ b/src/model/delegate/SubscribableProperty.kt
@@ -12,24 +12,24 @@ import kotlin.reflect.KProperty
  * @property subscribers MutableList<Function0<Unit>> - Subscriber, die bei Änderung benachrichtigt werden
  * @constructor
  */
-open class SubscribableDelegate<T, V : Any>(initialValue: V? = null) : ReadWriteProperty<T, V> {
+open class SubscribableProperty<T, V : Any>(initialValue: V? = null) : ReadWriteProperty<T, V> {
 
     private lateinit var value: V
 
-    private val subscribers: MutableList<() -> Unit> = mutableListOf()
+    val subscribers: MutableList<Subscriber> = mutableListOf()
 
     init {
         if (initialValue != null)
             value = initialValue
     }
 
-    fun subscribe(onChange: () -> Unit) {
-        subscribers += onChange
+    fun subscribe(subscriber: Subscriber) {
+        subscribers += subscriber
     }
 
     override fun getValue(thisRef: T, property: KProperty<*>): V {
         if (!this::value.isInitialized)
-            value = lazyInitialValue()
+            setValue(lazyInitialValue())
         return value
     }
 
@@ -45,6 +45,6 @@ open class SubscribableDelegate<T, V : Any>(initialValue: V? = null) : ReadWrite
         value = newValue
 
         if (oldValue == null || hasChanged(oldValue, newValue))
-            subscribers.forEach { it.invoke() }
+            subscribers.forEach(Subscriber::onValueChange)
     }
 }

--- a/src/model/delegate/Subscriber.kt
+++ b/src/model/delegate/Subscriber.kt
@@ -1,0 +1,5 @@
+package de.fhac.ewi.model.delegate
+
+interface Subscriber {
+    fun onValueChange()
+}

--- a/src/model/math/NodeEnergyDemandDelegate.kt
+++ b/src/model/math/NodeEnergyDemandDelegate.kt
@@ -19,7 +19,11 @@ class NodeEnergyDemandDelegate<T> : PipeBasedCalculableDelegate<T>() {
     }
 
     override fun onPipeConnect(pipe: Pipe) {
-        pipe::energyDemand.subscribeIfChanged(this::updateValue)
+        pipe::energyDemand.subscribeIfChanged(this)
+    }
+
+    override fun onPossiblePipeUpdate(pipe: Pipe) {
+        pipe.energyDemand
     }
 
 }

--- a/src/model/math/NodePressureLossDelegate.kt
+++ b/src/model/math/NodePressureLossDelegate.kt
@@ -17,7 +17,10 @@ class NodePressureLossDelegate<T> : PipeBasedCalculableDelegate<T>() {
     }
 
     override fun onPipeConnect(pipe: Pipe) {
-        pipe::totalPressureLoss.subscribeIfChanged(this::updateValue)
+        pipe::totalPressureLoss.subscribeIfChanged(this)
     }
 
+    override fun onPossiblePipeUpdate(pipe: Pipe) {
+        pipe.totalPressureLoss
+    }
 }

--- a/src/model/math/NodePumpPowerDelegate.kt
+++ b/src/model/math/NodePumpPowerDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Node
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.neededPumpPower
 import de.fhac.ewi.util.subscribeIfChanged
 
@@ -11,10 +11,10 @@ import de.fhac.ewi.util.subscribeIfChanged
  *
  * @param T - For Delegate
  */
-class NodePumpPowerDelegate<T>(private val node: Node) : CalculableDelegate<T>() {
+class NodePumpPowerDelegate<T>(private val node: Node) : LazyCalculableDoubleArray<T>() {
 
     init {
-        node::pressureLoss.subscribeIfChanged(this::updateValue)
+        node::pressureLoss.subscribeIfChanged(this)
         // volumeFlow does not need subscription, because it is in totalPressureLoss included
     }
 
@@ -22,4 +22,7 @@ class NodePumpPowerDelegate<T>(private val node: Node) : CalculableDelegate<T>()
         neededPumpPower(pressureLoss[index], volumeFlow[index])
     }
 
+    override fun checkForChanges() {
+        node.pressureLoss
+    }
 }

--- a/src/model/math/NodeVolumeFlowDelegate.kt
+++ b/src/model/math/NodeVolumeFlowDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Node
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.subscribeIfChanged
 import de.fhac.ewi.util.volumeFlow
 
@@ -11,20 +11,23 @@ import de.fhac.ewi.util.volumeFlow
  * ... setzt sich aus dem Temperaturunterschied zwischen Vorlauf und Rücklauf und dem Energiebedarf des Knotenpunkts und allem was daran angeschlossen ist zusammen.
  *
  * @param T - For Delegate
- * @property pipe Pipe - Die Rohrleitung des Delegates
+ * @property node Node - Die Knotenpunkt des Delegates
  * @constructor
  */
-class NodeVolumeFlowDelegate<T>(val node: Node) : CalculableDelegate<T>() {
+class NodeVolumeFlowDelegate<T>(val node: Node) : LazyCalculableDoubleArray<T>() {
 
     private val flowIn: DoubleArray by lazy { node.flowInTemperature.toDoubleArray() } // static
     private val flowOut: DoubleArray by lazy { node.flowOutTemperature.toDoubleArray() } // static
 
     init {
-        node::energyDemand.subscribeIfChanged(this::updateValue)
+        node::energyDemand.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int): Double {
         return volumeFlow(flowIn[index], flowOut[index], node.energyDemand[index])
     }
 
+    override fun checkForChanges() {
+        node.energyDemand
+    }
 }

--- a/src/model/math/PipeEnergyDemandDelegate.kt
+++ b/src/model/math/PipeEnergyDemandDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.subscribeIfChanged
 
 /**
@@ -13,15 +13,19 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipeEnergyDemandDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipeEnergyDemandDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     init {
-        pipe::heatLoss.subscribeIfChanged(this::updateValue)
-        pipe.target::energyDemand.subscribeIfChanged(this::updateValue)
+        pipe::heatLoss.subscribeIfChanged(this)
+        pipe.target::energyDemand.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
         heatLoss[index] + target.energyDemand[index]
     }
 
+    override fun checkForChanges() {
+        pipe.heatLoss // check if heatLoss has changed
+        pipe.target.energyDemand // check if target.energyDemand has changed
+    }
 }

--- a/src/model/math/PipeFlowRateDelegate.kt
+++ b/src/model/math/PipeFlowRateDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.flowRate
 import de.fhac.ewi.util.subscribeIfChanged
 
@@ -13,11 +13,11 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipeFlowRateDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipeFlowRateDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     init {
-        pipe::volumeFlow.subscribeIfChanged(this::updateValue)
-        pipe::type.subscribeIfChanged(this::updateValue)
+        pipe::volumeFlow.subscribeIfChanged(this)
+        pipe::type.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
@@ -25,4 +25,8 @@ class PipeFlowRateDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() 
         flowRate(type.diameter, volumeFlow[index])
     }
 
+    override fun checkForChanges() {
+        pipe.volumeFlow // check if volumeFlow has changed
+        // type changes will directly result in recalculation
+    }
 }

--- a/src/model/math/PipeHeatLossDelegate.kt
+++ b/src/model/math/PipeHeatLossDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.pipeHeatLoss
 import de.fhac.ewi.util.subscribeIfChanged
 
@@ -13,13 +13,13 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipeHeatLossDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipeHeatLossDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     private val flowIn: DoubleArray by lazy { pipe.source.flowInTemperature.toDoubleArray() } // static
     private val flowOut: DoubleArray by lazy { pipe.source.flowOutTemperature.toDoubleArray() } // static
 
     init {
-        pipe::type.subscribeIfChanged(this::updateValue)
+        pipe::type.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
@@ -33,6 +33,11 @@ class PipeHeatLossDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() 
             type.distanceBetweenPipes,
             length
         )
+    }
+
+
+    override fun checkForChanges() {
+        // type changes will directly result in recalculation
     }
 
 }

--- a/src/model/math/PipePressureLossDelegate.kt
+++ b/src/model/math/PipePressureLossDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.pipePressureLoss
 import de.fhac.ewi.util.subscribeIfChanged
 
@@ -13,15 +13,20 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipePressureLossDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipePressureLossDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     init {
-        pipe::flowRate.subscribeIfChanged(this::updateValue)
-        pipe::type.subscribeIfChanged(this::updateValue)
+        pipe::flowRate.subscribeIfChanged(this)
+        pipe::type.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
         pipePressureLoss(flowRate[index], length, type.diameter) * 2
+    }
+
+    override fun checkForChanges() {
+        pipe.flowRate // check if flowRate has changed
+        // type changes will directly result in recalculation
     }
 
 }

--- a/src/model/math/PipePumpPowerDelegate.kt
+++ b/src/model/math/PipePumpPowerDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.neededPumpPower
 import de.fhac.ewi.util.subscribeIfChanged
 
@@ -13,15 +13,19 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipePumpPowerDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipePumpPowerDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     init {
-        pipe::totalPressureLoss.subscribeIfChanged(this::updateValue)
-        // volumeFlow does not need subscription, because it is in totalPressureLoss included
+        pipe::totalPressureLoss.subscribeIfChanged(this)
+        pipe::volumeFlow.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
         neededPumpPower(totalPressureLoss[index], volumeFlow[index])
     }
 
+    override fun checkForChanges() {
+        pipe.totalPressureLoss // check if totalPressureLoss has changed
+        pipe.volumeFlow
+    }
 }

--- a/src/model/math/PipeTotalPressureLossDelegate.kt
+++ b/src/model/math/PipeTotalPressureLossDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.subscribeIfChanged
 
 /**
@@ -12,15 +12,20 @@ import de.fhac.ewi.util.subscribeIfChanged
  * @property pipe Pipe - Rohrleitung des Delegates
  * @constructor
  */
-class PipeTotalPressureLossDelegate<T>(private val pipe: Pipe) : CalculableDelegate<T>() {
+class PipeTotalPressureLossDelegate<T>(private val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     init {
-        pipe::pipePressureLoss.subscribeIfChanged(this::updateValue)
-        pipe.target::pressureLoss.subscribeIfChanged(this::updateValue)
+        pipe::pipePressureLoss.subscribeIfChanged(this)
+        pipe.target::pressureLoss.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int) = with(pipe) {
         pipePressureLoss[index] + target.pressureLoss[index]
+    }
+
+    override fun checkForChanges() {
+        pipe.pipePressureLoss // check if pipePressureLoss has changed
+        pipe.target.pressureLoss // check if target.pressureLoss has changed
     }
 
 }

--- a/src/model/math/PipeVolumeFlowDelegate.kt
+++ b/src/model/math/PipeVolumeFlowDelegate.kt
@@ -1,7 +1,7 @@
 package de.fhac.ewi.model.math
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.CalculableDelegate
+import de.fhac.ewi.model.delegate.LazyCalculableDoubleArray
 import de.fhac.ewi.util.subscribeIfChanged
 import de.fhac.ewi.util.volumeFlow
 
@@ -14,17 +14,21 @@ import de.fhac.ewi.util.volumeFlow
  * @property pipe Pipe - Die Rohrleitung des Delegates
  * @constructor
  */
-class PipeVolumeFlowDelegate<T>(val pipe: Pipe) : CalculableDelegate<T>() {
+class PipeVolumeFlowDelegate<T>(val pipe: Pipe) : LazyCalculableDoubleArray<T>() {
 
     private val flowIn: DoubleArray by lazy { pipe.source.flowInTemperature.toDoubleArray() } // static
     private val flowOut: DoubleArray by lazy { pipe.source.flowOutTemperature.toDoubleArray() } // static
 
     init {
-        pipe::energyDemand.subscribeIfChanged(this::updateValue)
+        pipe::energyDemand.subscribeIfChanged(this)
     }
 
     override fun recalculateIndexed(index: Int): Double {
         return volumeFlow(flowIn[index], flowOut[index], pipe.energyDemand[index])
+    }
+
+    override fun checkForChanges() {
+        pipe.energyDemand // check if energy demand has changed
     }
 
 }

--- a/src/util/DelegateUtil.kt
+++ b/src/util/DelegateUtil.kt
@@ -1,8 +1,7 @@
 package de.fhac.ewi.util
 
 import de.fhac.ewi.model.Pipe
-import de.fhac.ewi.model.delegate.PipeBasedCalculableDelegate
-import de.fhac.ewi.model.delegate.SubscribableDelegate
+import de.fhac.ewi.model.delegate.*
 import kotlin.reflect.KProperty0
 import kotlin.reflect.jvm.isAccessible
 
@@ -12,8 +11,8 @@ inline fun <reified R> KProperty0<*>.delegateAs(): R? {
     return getDelegate() as? R
 }
 
-fun KProperty0<*>.subscribeIfChanged(onChange: () -> Unit) {
-    delegateAs<SubscribableDelegate<*, *>>()?.subscribe(onChange)
+fun KProperty0<*>.subscribeIfChanged(subscriber: Subscriber) {
+    delegateAs<SubscribableProperty<*, *>>()?.subscribe(subscriber)
 }
 
 fun KProperty0<*>.addPipeIfNeeded(pipe: Pipe) {

--- a/test/model/GridOptimizerTest.kt
+++ b/test/model/GridOptimizerTest.kt
@@ -45,7 +45,7 @@ class GridOptimizerTest {
     fun testLargeGrid() {
         val grid = createLargeGrid()
         val optimizer = callOptimizer(grid)
-        assertEquals(217304.28, optimizer.gridCosts.totalPerYear.round(2))
+        assertEquals(217483.69, optimizer.gridCosts.totalPerYear.round(2))
     }
 
 

--- a/test/model/GridOptimizerTest.kt
+++ b/test/model/GridOptimizerTest.kt
@@ -56,7 +56,8 @@ class GridOptimizerTest {
                 ">> Wärmeverlust: ${(grid.totalHeatLoss / 1_000_000).round(3)} MWh (${((grid.totalHeatLoss / (grid.totalHeatLoss + grid.totalOutputEnergy)) * 100).round(1)} %)\n" +
                 ">> Druckverlust: ${grid.input.pressureLoss.maxOrNull()?.round(2)} Bar (max)\n" +
                 ">> Volumenstrom: ${String.format("%.6f", grid.input.volumeFlow.maxOrNull())} m^3/s (max)\n" +
-                ">> Pumpleistung: ${(grid.neededPumpPower / 1_000).round(3)} kW (max)\n")
+                ">> Pumpleistung: ${(grid.neededPumpPower / 1_000).round(3)} kW (max)\n" +
+                ">> Kritischer Pfad: ${grid.criticalPath.sumOf { it.length }} m Länge mit ${((grid.input.pressureLoss.maxOrNull()?:0.0) * 100_000 / grid.criticalPath.sumOf { it.length }).round(3)} Pa/m Druckverlust\n")
 
         println("> Costs\n" +
                 ">> Pipe Invest (Gesamt)   : ${optimizer.gridCosts.pipeInvestCostTotal.round(2).toString().padStart(8)} €\n" +

--- a/test/model/GridOptimizerTest.kt
+++ b/test/model/GridOptimizerTest.kt
@@ -31,14 +31,14 @@ class GridOptimizerTest {
     fun testSimpleGrid() {
         val grid = createSimpleGrid()
         val optimizer = callOptimizer(grid)
-        assertEquals(15296.67, optimizer.gridCosts.totalPerYear.round(2))
+        assertEquals(15305.58, optimizer.gridCosts.totalPerYear.round(2))
     }
 
     @Test
     fun testMediumGrid() {
         val grid = createMediumGrid()
         val optimizer = callOptimizer(grid)
-        assertEquals(44125.05, optimizer.gridCosts.totalPerYear.round(2))
+        assertEquals(44280.44, optimizer.gridCosts.totalPerYear.round(2))
     }
 
 


### PR DESCRIPTION
Um die Performance noch weiter zu verbessern, werden diese nun erst berechnet, wenn diese angefragt werden.
Dies spart hoffentlich weitere Berechnungen und damit noch mehr Zeit.